### PR TITLE
When long text is fed to oled.log(), wrap it.

### DIFF
--- a/lib/aiko/oled.py
+++ b/lib/aiko/oled.py
@@ -95,8 +95,16 @@ def log(text):
   for oled in oleds:
     oled.scroll(0, -font_size)
     oled.fill_rect(0, bottom_row, width, font_size, bg)
-    oled.text(text, 0, bottom_row, fg)
-    oled.show()
+    length = len(text) * font_size
+    if length > width:
+        snippet = text[0:int(width/font_size)]
+        oled.text(snippet, 0, bottom_row,fg)
+        oled.show()
+        log(text[len(snippet):])
+    else:
+        oled.text(text, 0, bottom_row, fg)
+        oled.show()
+
   if lock_title: write_title()
 
 def oleds_clear(bg):


### PR DESCRIPTION
It ignores space breaks for now, sacrificing legibility for compactness.

Things that could be done:
let it take an optional flag that is wrap vs truncate, for people invoking via code.
let it take an optional flag that is wrap-at-width vs wrap-on-space

They could be held in the config to set the defaults, but then overridden on each invocation?

Also not sure whether this will freak out the microprocessor/memory usage since it's implemented (lazily)
via recursion. Maybe a loop is better?