### PR TITLE
Show client IP after connecting instead of repeating SSID.

### DIFF
--- a/lib/aiko/net.py
+++ b/lib/aiko/net.py
@@ -78,8 +78,8 @@ def wifi_connect(wifi):
         sta_if.connect(ssid[0], ssid[1])
         for retry in range(WIFI_CONNECTING_RETRY_LIMIT):
           if sta_if.isconnected():
-            print(W + "Connected: " + ssid[0])
-            common.log("WiFi connected: " + ssid[0])
+            print(W + "Connected: " + sta_if.ifconfig()[0])
+            common.log("WiFi connected: " + sta_if.ifconfig()[0])
             connected = True
             wifi_configuration_update(wifi)
             break   # for retry


### PR DESCRIPTION
SSID is redundant the 2nd time and showing the client IP is more
useful for doing things like webrepl.