### PR TITLE
add oled:pixels command

### DIFF
--- a/lib/aiko/oled.py
+++ b/lib/aiko/oled.py
@@ -19,6 +19,7 @@
 # Topic: /in   (oled:clear)
 #              (oled:log This is a test !)
 #              (oled:pixel x y)
+#              (oled:pixels x y x y ...)
 #              (oled:text x y This is a test !)
 #              oled.bg=1; oled.fg=0
 #
@@ -231,6 +232,15 @@ def on_oled_message(topic, payload_in):
     tokens = [int(token) for token in payload_in[12:-1].split()]
     for oled in oleds:
       oled.pixel(tokens[0], height - tokens[1] - 1, FG)
+    oleds_show()
+    return True
+
+  if payload_in.startswith("(oled:pixels "):
+    tokens = [int(token) for token in payload_in[12:-1].split()]
+    token_pairs = [ (x, y) for x, y in zip( tokens[0 :: 2], tokens[1 :: 2] ) ]
+    for oled in oleds:
+      for x, y in token_pairs:
+        oled.pixel(x, height - y - 1, FG)
     oleds_show()
     return True
 


### PR DESCRIPTION
Adds a new MQTT command to render a range of pixels in one payload.

I haven't yet gotten onto the device itself, so I only assume that this will work.