### PR TITLE
add blit to mqtt functions

### DIFF
--- a/lib/aiko/oled.py
+++ b/lib/aiko/oled.py
@@ -20,6 +20,8 @@
 #              (oled:log This is a test !)
 #              (oled:pixel x y)
 #              (oled:text x y This is a test !)
+#              (oled:blit0 {base64 bits} {base64 bits} ...)
+#              (oled:blit1 {base64 bits} {base64 bits} ...)
 #              oled.bg=1; oled.fg=0
 #
 # Topic: /in   (oled:traits)
@@ -244,16 +246,10 @@ def on_oled_message(topic, payload_in):
     oleds_show()
     return True
 
-  if payload_in.startswith("(oled:npixel "):
-    tokens = [int(token) for token in payload_in[12:-1].split()]
-    for oled in oleds:
-      oled.pixel(tokens[0], height - tokens[1] - 1, BG)
-    oleds_show()
-    return True
-
-  if payload_in.startswith("(oled:blit "):
-    blit = payload_in[11:-1].split()
-    out = 1
+  if (payload_in.startswith("(oled:blit0 ") or
+    payload_in.startswith("(oled:blit1 ")):
+    blit = payload_in[12:-1].split()
+    out = ord(payload_in[10])-0x30
     image = bytearray(128//8*64+1)
     line = 0
     for blitline in blit:

--- a/lib/aiko/oled.py
+++ b/lib/aiko/oled.py
@@ -234,6 +234,41 @@ def on_oled_message(topic, payload_in):
     oleds_show()
     return True
 
+  if payload_in.startswith("(oled:npixel "):
+    tokens = [int(token) for token in payload_in[12:-1].split()]
+    for oled in oleds:
+      oled.pixel(tokens[0], height - tokens[1] - 1, BG)
+    oleds_show()
+    return True
+
+  if payload_in.startswith("(oled:blit "):
+    blit = payload_in[11:-1].split()
+    line = 0
+    for blitline in blit:
+      column = 0
+      for c in blitline:
+        bits = 0
+        nh = ord(c) & 0x60
+        nl = ord(c) & 0x1F
+        if nh == 0x20:
+          bits = nl-0x10+52
+          if nl == 0x0B:
+            bits = 0x3E
+          elif nl == 0x0F:
+            bits = 0x3F
+        elif nh == 0x40:
+          bits = nl-1+0
+        elif nh == 0x60:
+          bits = nl-1+26
+        m = 32
+        while m > 0:
+          oleds[1].pixel(column, line, int(bits&m == m))
+          column = column + 1
+          m = m >> 1
+      line = line + 1
+    oleds_show()
+    return True
+
   # (oled:text x y message)
   if payload_in.startswith("(oled:text "):
     tokens = payload_in[11:-1].split()


### PR DESCRIPTION
Andy - these are the changes I made to oled.py to allow for the oled:blit0 and oled:blit1 functions - I must confess I don't really know how to Python.
The blit arguments are base64 encoded strings, one string per line, and it is blitted starting at the top left corner of the chosen screen.

example usage
`(oled:blit1 ////////+ ////9v//+ ////ff//+ ///9////+ ///3/9//+ ////////+ ////r///+ ///5+9//+ ////3r//+ ////33//+ ///+i///+ ///z/X//+ ///f/9//+ //+6qvf/+ //7ASBv/+ //3Cqp3/+ //uVVQ7/+ //2FVUd/+ //cEqo//+ //eKpUq/+ //6GvUe/+ /+eHnqq/+ //4Pt0f/+ /++Fs6e/+ //cMVk2/+ //eFV0f/+ //2FUK5/+ //uCrqf/+ //2KoU7/+ //7JWq3/+ //9kpFv/+ //++t+f/+ ///H/RP/+ //+0hdX/+ //8v/yr/+ //6l/9V/+ //6vbar/+ //yv79I/+ //qtfdW/+ //pf7tSf+ //q3e+lf+ //K933Vf+ //S3deiv+ /+q/v3av+ //Tt7fVP+ /+p/f7Fv+ /+Vq1c0v+ /+k//uVf+ /+qu95VP+ /+qnv9E3+ /xUr9VSn+ /qqpv1a3+ /VVX/1VP+ /qqS11Vj+ /qqr/yqV+ /qqje6rV+ /qqq3FVX+ /VVVRqqn+ /VqpUlVf+ /1VVKVV/+ //VV/1T/+ //1X/9X/+ ///f/6f/+ ////////+)`

To do the screen capture, I just used some dirty C++ code https://pastebin.com/cyPbdUNF to snapshot, reduce down and dither, and ran it from a script which called mosquitto_pub to periodically publish the capture.