### PR TITLE
Fix to let load_image work with P4 and P1 type PBM files

### DIFF
--- a/lib/aiko/oled.py
+++ b/lib/aiko/oled.py
@@ -136,8 +136,13 @@ def oleds_system_use(system_use):
 
 def load_image(filename):
   with open(filename, 'rb') as file:
-    file.readline()  # magic number: P4
-    file.readline()  # creator comment
+    # pbm formats: http://netpbm.sourceforge.net/doc/pbm.html
+    # P4 format is P4 [ whitespace ] [width] [height] [whitespace] [image data]
+    # P1 format is P1 [whitespace] # creator comment [whitespace] [width] [height] [image data]
+    
+    line = file.readline()  # read magic number (P4 or P1)
+    if "P1" in line:
+        file.readline()  # skip the creator comment
     width, height = [int(value) for value in file.readline().split()]
     image = bytearray(file.read())
   return framebuf.FrameBuffer(image, width, height, framebuf.MONO_HLSB)


### PR DESCRIPTION
I was today years old when I found out there's two different
PBM image formats:
http://netpbm.sourceforge.net/doc/pbm.html
P4 doesn't have a creator comment, P1 does.

    P4 [ whitespace ] [width] [height] [whitespace] [image data]
    P1 [whitespace] # creator comment [whitespace] [width] [height] [image data]

This patch detects if the file format is P1 and skips over the creator comment to find the width and height.