### PR TITLE
Fix network connection after soft-boot.

### DIFF
--- a/lib/aiko/net.py
+++ b/lib/aiko/net.py
@@ -61,6 +61,13 @@ def set_status(color):
 #
 # Returns sta_if: Wi-Fi Station reference
 
+def report_connected(sta_if):
+  global connected
+  print(W + "Connected: " + sta_if.ifconfig()[0])
+  common.log("WiFi connected: " + sta_if.ifconfig()[0])
+  connected = True
+  return sta_if
+
 def wifi_connect(wifi):
   global connected
   sta_if = network.WLAN(network.STA_IF)
@@ -78,17 +85,13 @@ def wifi_connect(wifi):
         sta_if.connect(ssid[0], ssid[1])
         for retry in range(WIFI_CONNECTING_RETRY_LIMIT):
           if sta_if.isconnected():
-            print(W + "Connected: " + sta_if.ifconfig()[0])
-            common.log("WiFi connected: " + sta_if.ifconfig()[0])
-            connected = True
             wifi_configuration_update(wifi)
-            break   # for retry
-#         print(W + "Waiting")
+            return report_connected(sta_if)
           sleep_ms(WIFI_CONNECTING_CLIENT_PERIOD)
-        if sta_if.isconnected(): break  # for ssid
         print(W + "Timeout: Bad password ?")
         common.log("Timeout:        Bad password ?")
-    if sta_if.isconnected(): break  # for ap
+    if sta_if.isconnected():  # ap or soft-reboot with WiFi enabled
+      return report_connected(sta_if)
   return sta_if
 
 def wifi_configuration_update(wifi):


### PR DESCRIPTION
When the LOLIN32 re-connected we got `sta_if.isconnected` and interpreted it as AP mode, in which we didn't set the global `connected`. In turn `is_connected()` stayed false, and `aiko.mqtt.mqtt_thread` would never try to connect, but `ping` would work.

This change ensures `is_connected()` returns True if we wake with `network.WLAN(network.STA_IF).isconnected()` returning True.

Tested with hard reset, `mpfshell --reset`, and soft reboot with `connection.net.wifi` either configured or left to its AP defaults.