### PR TITLE
flash_swagbadge.sh only generate keys when not found.

### DIFF
--- a/scripts/flash_swagbadge.sh
+++ b/scripts/flash_swagbadge.sh
@@ -18,29 +18,39 @@ KEYS_PATHNAME=z_keys
 KEYS_INDEX=$KEYS_PATHNAME/index
 KEYS_LOG_PATHNAME=$KEYS_PATHNAME/allocated_keys.log
 
-# If not already saved, then save default "configuration/keys.db"
-#
-if [ ! -f "${CONFIGURATION_KEY_FILENAME}_default" ]; then
-  mv $CONFIGURATION_KEY_FILENAME ${CONFIGURATION_KEY_FILENAME}_default 2>/dev/null
+# If key is non default don't generate a new one
+ORIGINAL_KEY=$(cat $CONFIGURATION_KEY_FILENAME | cut -d "=" -f2)
+if [ $ORIGINAL_KEY != "0000000000000000000000000000000000000000000000000000000000000000" ]; then
+  SKIP_KEY_GEN=1
+  echo "Key found, Skipping new key generation"
 fi
 
-# Determine next "keys_$INDEX.db" file to use
-#
-INDEX=0000`cat $KEYS_INDEX`
-INDEX=${INDEX: -4}
-KEYS_FILENAME=$KEYS_PATHNAME/keys_$INDEX.db
+if [ -z "$SKIP_KEY_GEN" ]; then
+  # If not already saved, then save default "configuration/keys.db"
+  #
+  if [ ! -f "${CONFIGURATION_KEY_FILENAME}_default" ]; then
+    mv $CONFIGURATION_KEY_FILENAME ${CONFIGURATION_KEY_FILENAME}_default 2>/dev/null
+  fi
 
-# Check if "keys_$INDEX.db" file exists
-#
-if [ ! -f "$KEYS_FILENAME" ]; then
-  echo "$KEYS_FILENAME does not exist, you've run out of unique keys !"
-  exit
+  # Determine next "keys_$INDEX.db" file to use
+  #
+  INDEX=0000`cat $KEYS_INDEX`
+  INDEX=${INDEX: -4}
+  KEYS_FILENAME=$KEYS_PATHNAME/keys_$INDEX.db
+
+  # Check if "keys_$INDEX.db" file exists
+  #
+  if [ ! -f "$KEYS_FILENAME" ]; then
+    echo "$KEYS_FILENAME does not exist, you've run out of unique keys !"
+    exit
+  fi
+
+  # Use unique "keys_$INDEX.db" when flashing ESP32
+  #
+  cp $KEYS_FILENAME $CONFIGURATION_KEY_FILENAME
+  echo "Index is $INDEX and using $KEYS_FILENAME"
 fi
 
-# Use unique "keys_$INDEX.db" when flashing ESP32
-#
-cp $KEYS_FILENAME $CONFIGURATION_KEY_FILENAME
-echo "Index is $INDEX and using $KEYS_FILENAME"
 echo "###########################################"
 
 # Erase, flash microPython and flash Aiko Engine to ESP32
@@ -52,32 +62,41 @@ echo "###########################################"
 # Display the unique key INDEX (up-one integer) and ESP32 serial id
 #
 DEVICE_SERIAL_ID=`./scripts/device_info.py $AMPY_PORT 2>&1 | grep passed | cut -d\' -f2`
-echo "Index is $INDEX for ESP32 serial id: $DEVICE_SERIAL_ID"
-
-# Increment unique key index value
-#
-INDEX=`cat $KEYS_INDEX`
-echo `expr $INDEX + 1` >$KEYS_INDEX
-
-# Update allocated keys log file "INDEX:DEVICE_SERIAL_ID"
-# Record count should increment by one, each time
-#
-touch $KEYS_LOG_PATHNAME
-KEYS_LOG_OLD_LENGTH=`wc -l $KEYS_LOG_PATHNAME | column -t | cut -d" " -f1`
-KEYS_LOG_OUTPUT="$INDEX:$DEVICE_SERIAL_ID"
-echo $KEYS_LOG_OUTPUT >>$KEYS_LOG_PATHNAME
-KEYS_LOG_NEW_LENGTH=`wc -l $KEYS_LOG_PATHNAME | column -t | cut -d" " -f1`
-echo "$KEYS_LOG_PATHNAME record count: $KEYS_LOG_OLD_LENGTH -> $KEYS_LOG_NEW_LENGTH"
-
-DUPLICATES_COUNT=`cut -d: -f1 $KEYS_LOG_PATHNAME | sort | uniq -d | wc -l | column -t`
-if [ $DUPLICATES_COUNT -eq 0 ]; then
-    echo "No duplicate key index used :)"
+if [ -z "$DEVICE_SERIAL_ID" ]; then
+  echo "Testing failed, see ./scripts/device_info.py for more details"
+  exit
 else
+  echo "$DEVICE_SERIAL_ID succesfully flashed"
+fi
+
+if [ -z "$SKIP_KEY_GEN" ]; then
+  echo "Index is $INDEX for ESP32 serial id: $DEVICE_SERIAL_ID"
+
+  # Increment unique key index value
+  #
+  INDEX=`cat $KEYS_INDEX`
+  echo `expr $INDEX + 1` >$KEYS_INDEX
+
+  # Update allocated keys log file "INDEX:DEVICE_SERIAL_ID"
+  # Record count should increment by one, each time
+  #
+  touch $KEYS_LOG_PATHNAME
+  KEYS_LOG_OLD_LENGTH=`wc -l $KEYS_LOG_PATHNAME | column -t | cut -d" " -f1`
+  KEYS_LOG_OUTPUT="$INDEX:$DEVICE_SERIAL_ID"
+  echo $KEYS_LOG_OUTPUT >>$KEYS_LOG_PATHNAME
+  KEYS_LOG_NEW_LENGTH=`wc -l $KEYS_LOG_PATHNAME | column -t | cut -d" " -f1`
+  echo "$KEYS_LOG_PATHNAME record count: $KEYS_LOG_OLD_LENGTH -> $KEYS_LOG_NEW_LENGTH"
+
+  DUPLICATES_COUNT=`cut -d: -f1 $KEYS_LOG_PATHNAME | sort | uniq -d | wc -l | column -t`
+  if [ $DUPLICATES_COUNT -eq 0 ]; then
+    echo "No duplicate key index used :)"
+  else
     echo "ERROR: Duplicate key index count: $DUPLICATES_COUNT"
     DUPLICATES=`cut -d: -f1 $KEYS_LOG_PATHNAME | sort | uniq -d | xargs echo`
     echo "ERROR: Duplicate key index: $DUPLICATES"
-fi
+  fi
 
-# Restore default "configuration/keys.db"
-#
-mv ${CONFIGURATION_KEY_FILENAME}_default $CONFIGURATION_KEY_FILENAME
+  # Restore default "configuration/keys.db"
+  #
+  mv ${CONFIGURATION_KEY_FILENAME}_default $CONFIGURATION_KEY_FILENAME
+fi


### PR DESCRIPTION
If configuration/keys.db has a non zero key then don't attempt to
generate a new one. This means users can use mpfshell to read the
key and network settings, add them to configuration/keys.db and
configuration/net.py and use this script to update there 2021
badge.

I'm open to other approaches to pass through the key but this 
seamed the simplest.